### PR TITLE
Build: selenium-webdriver should be a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
   "dependencies": {
     "axe-core": "~1.0"
   },
+  "peerDependencies": {
+    "selenium-webdriver": "^2.46.1"
+  },
   "devDependencies": {
     "axe-core": "~1.0.1",
     "chai": "^3.0.0",


### PR DESCRIPTION
For once you start accepting pull requests

Fixes #1
Closes #2