### PR TITLE
added missing dependencies to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "devDependencies": {
     "chai": "^3.0.0",
     "grunt": "^0.4.5",
+    "grunt-cli": "^0.1.13",
     "grunt-contrib-connect": "^0.10.1",
     "grunt-contrib-jshint": "^0.11.2",
     "grunt-contrib-watch": "^0.6.1",
@@ -45,6 +46,7 @@
     "istanbul": "^0.3.15",
     "mocha": "^2.2.5",
     "proxyquire": "^1.5.0",
+    "selenium-webdriver": "^2.53.1",
     "serve-static": "^1.9.3"
   }
 }


### PR DESCRIPTION
`npm test` is assuming `grunt-cli` to be installed globally, if `grunt-cli` is not installed globally it errors out.

```sh
> axe-webdriverjs@0.2.0 test /Users/sabandyo/GitHub/axe-webdriverjs
> grunt test

sh: grunt: command not found
npm ERR! Test failed.  See above for more details.
npm WARN Local package.json exists, but node_modules missing, did you mean to install?
```

similarly for `selenium-webdriver`

```
Running "mochaTest:integration" (mochaTest) task
>> Mocha exploded!
>> Error: Cannot find module 'selenium-webdriver'
>>     at Function.Module._resolveFilename (module.js:339:15)
>>     at Function.Module._load (module.js:290:25)
>>     at Module.require (module.js:367:17)
>>     at require (internal/module.js:16:19)
>>     at Object.<anonymous> (/Users/sabandyo/GitHub/axe-webdriverjs/test/integration/doc-lang.js:1:79)
>>     at Module._compile (module.js:413:34)
>>     at Object.Module._extensions..js (module.js:422:10)
>>     at Module.load (module.js:357:32)
>>     at Function.Module._load (module.js:314:12)
>>     at Module.require (module.js:367:17)
```
     