### PR TITLE
Remove ~ with ^ to get more versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "peerDependencies": {
     "selenium-webdriver": "^2.46.1",
-    "axe-core": "~2.0.5"
+    "axe-core": "^2.0.5"
   },
   "devDependencies": {
     "chai": "^3.0.0",


### PR DESCRIPTION
Fix #19.

[Due to the ~2.0.5](https://semver.npmjs.com/), you can´t get the version 2.1.7.

In an old version of npm, the instalation will fail. In a new one, you will obtain a warning message. 