### PR TITLE
Changelog formatting tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,27 @@
-# Change log
+# Change Log
+
+<!-- Release notes authoring guidelines: http://keepachangelog.com/ -->
+
 All notable changes to this project will be documented in this file.
 
-## [0.2.0] - 2015-08-16
-### Changed
-	- Update to use aXe 1.1.0
-
-## [0.4.0] - 2016-09-27
-### Added
-	- New configure method building on axe-core API
+<!-- ## [Unreleased] -->
 
 ## [0.5.0] - 2016-12-22
 ### Added
-	- Support for axe-cli by passing in a source for axe-core version
+- Support for axe-cli by passing in a source for axe-core version
 
 ### Changed
-	- Upgrade to Selenium 3, which requires Node 6
-	- Replace ~ with ^ in package.json to get more 
-	- Allow running with Selenium remotely in tests
+- Upgrade to Selenium 3, which requires Node 6
+- Replace `~` with `^` in package.json to get more 
+- Allow running with Selenium remotely in tests
+
+## 0.4.0 - 2016-09-27
+### Added
+- New configure method building on axe-core API
+
+## 0.2.0 - 2015-08-16
+### Changed
+- Update to use aXe 1.1.0
+
+[Unreleased]: https://github.com/dequelabs/axe-webdriverjs/compare/v0.5.0...master
+[0.5.0]: https://github.com/dequelabs/axe-webdriverjs/compare/8d6cd08fabf507134fe3c6cf33516af00d8f4eb8...v0.5.0


### PR DESCRIPTION
Thanks for including release notes and tagging releases in GitHub!

This PR introduces these changes to the changelog:

- reorders versions to show the latest at the top
- Adds links to unreleased changes and commit log between 0.4.0 and 0.5.0
- Adds a link to the keepchangelog.com guidelines in comments
- reformat markdown to follow above guidelines

If you have questions about the `[x.x.x]` link notation, let me know!

### `[Unreleased]`

This link (commented for now) allows you to add pending changes that aren't released yet.

e.g.

```md
## [Unreleased]
### Changed
- Something changed

...
...
[Unreleased]: https://github.com/dequelabs/axe-webdriverjs/compare/v0.5.0...master
```

Then, when you're ready to release the next version (e.g. v0.6.0), you replace `Unreleased` with the version name (and update the link at the bottom of the file). This is very handy to track changes between versions.

Again, if anything is unclear, let me know.