### PR TITLE
Inject aXe-core via direct evaluation if script tag fails (Chrome and Firefox CSP workaround)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -103,21 +103,27 @@ AxeBuilder.prototype.analyze = function(callback) {
     config = this._config,
     source = this._source;
 
+  var runAxe = function(context, options, config) {
+    /*global document, axe */
+    if (config !== null) {
+      axe.configure(config);
+    }
+    axe.a11yCheck(context || document, options, arguments[arguments.length - 1]);
+  };
+
+  var scriptWrapper = [
+    'if (!(typeof axe === "object" && axe.version)) {',
+    '  // The script-element injection approach did not work, perhaps',
+    '  // due to Content Security Policy, so we will fall back to just',
+    '  // evaluating the source.',
+    '  ' + (source || require('axe-core').source),
+    '}',
+    '(' + runAxe.toString() + ').apply(this, arguments);',
+  ].join('\n');
+
 	inject(driver, source, function() {
 		driver
-			.executeAsyncScript(function(context, options, config, source) {
-        if (!(typeof axe === "object" && axe.version)) {
-          // The script-element injection approach didn't work, perhaps
-          // due to Content Security Policy, so we'll fall back to just
-          // evaluating the source.
-          eval(source);
-        }
-				/*global document, axe */
-				if (config !== null) {
-					axe.configure(config);
-				}
-				axe.a11yCheck(context || document, options, arguments[arguments.length - 1]);
-			}, context, options, config, source || require('axe-core').source)
+			.executeAsyncScript(scriptWrapper, context, options, config)
 			.then(callback);
 	});
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -105,13 +105,19 @@ AxeBuilder.prototype.analyze = function(callback) {
 
 	inject(driver, source, function() {
 		driver
-			.executeAsyncScript(function(context, options, config) {
+			.executeAsyncScript(function(context, options, config, source) {
+        if (!(typeof axe === "object" && axe.version)) {
+          // The script-element injection approach didn't work, perhaps
+          // due to Content Security Policy, so we'll fall back to just
+          // evaluating the source.
+          eval(source);
+        }
 				/*global document, axe */
 				if (config !== null) {
 					axe.configure(config);
 				}
 				axe.a11yCheck(context || document, options, arguments[arguments.length - 1]);
-			}, context, options, config)
+			}, context, options, config, source || require('axe-core').source)
 			.then(callback);
 	});
 };


### PR DESCRIPTION
So I did some tinkering on the problem I described in #28 and discovered that what Chrome Webdriver really doesn't like is injecting inline `<script>` tags on CSP-enabled pages that prohibit such things--but webdriver's own `executeScript`/`executeAsyncScript` work just fine.  Chrome allows calling `eval()` in such contexts even if the page's CSP prohibits it, but Firefox doesn't.

So this implements some fallback logic whereby, at the time that `axe` is needed, if it doesn't exist due to CSP, we just evaluate the aXe source code inline.

(Note: I originally tried modifying the script in `inject.js` to just evaluate aXe's source code directly rather than wrapping it in a `<script>`, but this only worked on Chrome--it broke all tests on Firefox.  You can see this attempt in aa550adc5617ef327ff585f95ccfe4459fbc026e.)

This PR does currently have some limitations, though:

* `inject.js` additionally calls `axe.configure()` but this fallback/workaround doesn't.
* `inject.js` recursively injects aXe into all iframes, but this fallback/workaround doesn't.
* I haven't added any tests to verify this functionality works, but I do have a manual test (see below). I can add automated tests to do this if the rest of this PR seems OK to you.

## Manual testing

Run this script from the root of the repo:

```js
var AxeBuilder = require('./lib');
var WebDriver = require('selenium-webdriver');

var driver = new WebDriver.Builder()
  .forBrowser('firefox')
  .build();

driver
  .get('https://github.com/dequelabs/axe-webdriverjs')
  .then(function () {
    AxeBuilder(driver)
      .analyze(function (results) {
        console.log(results);
      });
  });
```

Due to the fact that different browsers behave differently when a site is CSP'd, it might make sense to actually run these CSP-related tests on multiple browsers. So far I've tested on Firefox and Chrome and they seem to work with this fallback approach.
