### PR TITLE
fix: Ensure that when the injection of axe-core into an iframe fails,…

### DIFF
--- a/lib/inject.js
+++ b/lib/inject.js
@@ -27,6 +27,7 @@ function findFramesAndInject(parent, script, driver) {
 							});
 					}).catch(function (e) {
 						console.log('Failed to inject axe-core into one of the iframes!');
+						driver.switchTo().defaultContent();
 					});
 			});
 		});


### PR DESCRIPTION
… the driver context is reset to something meaningful

I could not simulate the slow loading iframe in an integration test...I tried :-( ask @anikg, he was with me :-)