### PR TITLE
fix: Prevent infinitely recursing when injecting into iframes

### DIFF
--- a/lib/inject.js
+++ b/lib/inject.js
@@ -4,8 +4,14 @@
  * @param  {Array}  parent Array of parent frames; or falsey if top level frame
  * @param  {String} script The script to inject
  * @param  {WebDriver} driver The driver to inject into
+ * @param  {Number} [depth] The recursion depth
  */
-function findFramesAndInject(parent, script, driver) {
+function findFramesAndInject(parent, script, driver, depth) {
+	depth = depth || 0;
+	// Prevent infinite recursion (see https://github.com/dequelabs/axe-webdriverjs/issues/63)
+	if (depth > 10) {
+		return;
+	}
 	driver
 		.findElements({
 			tagName: 'iframe'
@@ -23,7 +29,7 @@ function findFramesAndInject(parent, script, driver) {
 						driver
 							.executeScript(script)
 							.then(function() {
-								findFramesAndInject((parent || []).concat(frame), script, driver);
+								findFramesAndInject((parent || []).concat(frame), script, driver, depth + 1);
 							});
 					}).catch(function (e) {
 						console.log('Failed to inject axe-core into one of the iframes!');
@@ -53,7 +59,7 @@ module.exports = function(driver, axeSource, config, callback) {
 	driver
 		.executeScript(script)
 		.then(function() {
-			findFramesAndInject(null, script, driver);
+			findFramesAndInject(null, script, driver, 0);
 		})
 		.then(function() {
 			driver.switchTo().defaultContent();

--- a/test/integration/gh-63-garmin.js
+++ b/test/integration/gh-63-garmin.js
@@ -1,0 +1,24 @@
+var assert = require('chai').assert;
+var runWebdriver = require('../run-webdriver');
+var AxeBuilder = require('../..');
+
+describe('gh-63: buy.garmin.com/en-US/US/p/591046', function () {
+  this.timeout('1m');
+
+  var driver;
+  before(function () {
+    driver = runWebdriver();
+    return driver.get('https://buy.garmin.com/en-US/US/p/591046');
+  });
+
+  after(function () {
+    return driver.quit();
+  });
+
+  it('should not timeout', function (done) {
+    var axe = new AxeBuilder(driver);
+    axe.analyze(function () {
+      done();
+    });
+  });
+});

--- a/test/integration/gh-63-garmin.js
+++ b/test/integration/gh-63-garmin.js
@@ -8,6 +8,7 @@ describe('gh-63: buy.garmin.com/en-US/US/p/591046', function () {
   var driver;
   before(function () {
     driver = runWebdriver();
+    driver.manage().timeouts().setScriptTimeout(5000);
     return driver.get('https://buy.garmin.com/en-US/US/p/591046');
   });
 


### PR DESCRIPTION
This patch prevents `axe-webdriverjs` to infinitely recurse when injecting `axe-core` into `<iframe>`s. Instead of looping forever, we'll recurse 10 times before giving up. Closes #63.