### PR TITLE
ci: use Node.js v10 image

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ version: 2
 
 defaults: &defaults
   docker:
-    - image: circleci/node:6-browsers
+    - image: circleci/node:10-browsers
   working_directory: ~/axe-webdriverjs
 
 jobs:


### PR DESCRIPTION
This helps ensure we're using an up-to-date version of npm.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @wilcofiers
