### PR TITLE
BREAKING CHANGE: Allow errors bubble up to the caller

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -128,7 +128,7 @@ AxeBuilder.prototype.analyze = function(callback) {
     config = this._config,
     source = this._source;
 
-  return new Promise(function(resolve) {
+  return new Promise(function(resolve, reject) {
     var injector = new AxeInjector({ driver, axeSource: source, config });
     injector.inject(() => {
       driver
@@ -148,9 +148,17 @@ AxeBuilder.prototype.analyze = function(callback) {
         )
         .then(function(results) {
           if (callback) {
-            callback(results);
+            callback(null, results);
           }
           resolve(results);
+        })
+        .catch(err => {
+          // If provided a callback, do not reject. This ensures we don't have to handle the same error twice.
+          if (callback) {
+            callback(err);
+          } else {
+            reject(err);
+          }
         });
     });
   });

--- a/test/integration/configure-frames.js
+++ b/test/integration/configure-frames.js
@@ -56,7 +56,8 @@ describe('outer-configure-frame.html', function() {
         }
       })
       .configure(json)
-      .analyze(function(results) {
+      .analyze(function(err, results) {
+        assert.isNull(err);
         assert.equal(results.violations[0].id, 'dylang');
         // the second violation is in a frame
         assert.equal(results.violations[0].nodes.length, 2);

--- a/test/integration/doc-dylang.js
+++ b/test/integration/doc-dylang.js
@@ -53,7 +53,8 @@ describe('doc-dylang.html', function() {
     AxeBuilder(driver, src)
       .configure(json)
       .withRules(['dylang'])
-      .analyze(function(results) {
+      .analyze(function(err, results) {
+        assert.isNull(err);
         assert.lengthOf(results.violations, 1);
         assert.equal(results.violations[0].id, 'dylang');
         assert.notEqual(

--- a/test/integration/doc-lang.js
+++ b/test/integration/doc-lang.js
@@ -43,7 +43,8 @@ describe('doc-lang.html', function() {
   it('should find violations', function(done) {
     AxeBuilder(driver)
       .withRules('html-has-lang')
-      .analyze(function(results) {
+      .analyze(function(err, results) {
+        assert.isNull(err);
         assert.lengthOf(results.violations, 1);
         assert.equal(results.violations[0].id, 'html-has-lang');
         assert.lengthOf(results.passes, 0);
@@ -55,7 +56,8 @@ describe('doc-lang.html', function() {
     AxeBuilder(driver)
       .include('body')
       .withRules('html-has-lang')
-      .analyze(function(results) {
+      .analyze()
+      .then(function(results) {
         assert.lengthOf(results.violations, 0);
         assert.lengthOf(results.passes, 0);
         done();
@@ -65,7 +67,8 @@ describe('doc-lang.html', function() {
   it('should not find violations when the rule is disabled', function(done) {
     AxeBuilder(driver)
       .options({ rules: { 'html-has-lang': { enabled: false } } })
-      .analyze(function(results) {
+      .analyze()
+      .then(function(results) {
         results.violations.forEach(function(violation) {
           assert.notEqual(violation.id, 'html-has-lang');
         });

--- a/test/integration/frames.js
+++ b/test/integration/frames.js
@@ -45,7 +45,8 @@ describe('outer-frame.html', function() {
   it('should find violations', function(done) {
     AxeBuilder(driver)
       .withRules('html-lang-valid')
-      .analyze(function(results) {
+      .analyze()
+      .then(function(results) {
         assert.lengthOf(results.violations, 1, 'violations');
         assert.equal(results.violations[0].id, 'html-lang-valid');
         assert.lengthOf(
@@ -71,7 +72,8 @@ describe('outer-frame.html', function() {
       .include('body')
       .options({ checks: { 'valid-lang': { options: ['bobbert'] } } })
       .withRules('html-lang-valid')
-      .analyze(function(results) {
+      .analyze()
+      .then(function(results) {
         assert.lengthOf(results.violations, 0);
         assert.lengthOf(results.passes, 1);
         done();
@@ -81,7 +83,8 @@ describe('outer-frame.html', function() {
   it('should not find violations when the rule is disabled', function(done) {
     AxeBuilder(driver)
       .options({ rules: { 'html-lang-valid': { enabled: false } } })
-      .analyze(function(results) {
+      .analyze()
+      .then(function(results) {
         results.violations.forEach(function(violation) {
           assert.notEqual(violation.id, 'html-lang-valid');
         });

--- a/test/integration/shadow-dom.js
+++ b/test/integration/shadow-dom.js
@@ -72,7 +72,8 @@ describe('shadow-dom.html', function() {
             region: { enabled: false }
           }
         })
-        .analyze(function(results) {
+        .analyze()
+        .then(function(results) {
           assert.lengthOf(results.violations, 2);
           assert.equal(results.violations[0].id, 'aria-roles');
           assert.equal(results.violations[1].id, 'aria-valid-attr');

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -154,7 +154,8 @@ describe('Builder', function() {
         }
       })
         .configure(catsConfig)
-        .analyze(function(results) {
+        .analyze(function(err, results) {
+          assert.isNull(err);
           assert.equal(results, 'results');
           done();
         });
@@ -246,7 +247,8 @@ describe('Builder', function() {
         }
       })
         .options({ foo: 'bar' })
-        .analyze(function(results) {
+        .analyze(function(err, results) {
+          assert.isNull(err);
           assert.equal(results, 'results');
           done();
         });
@@ -292,7 +294,8 @@ describe('Builder', function() {
           };
         }
       })
-        .analyze(function(results) {
+        .analyze(function(err, results) {
+          assert.isNull(err);
           assert.equal(results, 'results');
           assert.equal(called, false);
           called = true;
@@ -301,6 +304,43 @@ describe('Builder', function() {
           assert.equal(called, true);
           done();
         });
+    });
+
+    describe('when `executeAsyncScript` fails', () => {
+      it('should not crash the process', async () => {
+        const builder = new Builder({
+          executeAsyncScript() {
+            return Promise.reject(new Error('boom!'));
+          }
+        });
+
+        let error = null;
+        try {
+          await builder.analyze();
+        } catch (err) {
+          error = err;
+        }
+        assert.ok(error);
+        assert.equal(error.message, 'boom!');
+      });
+
+      describe('given a callback', () => {
+        it('should provide the error', done => {
+          const builder = new Builder({
+            executeAsyncScript() {
+              return Promise.reject(new Error('boom!'));
+            }
+          });
+
+          builder.analyze((err, result) => {
+            assert.isOk(err);
+            assert.isNotOk(result);
+
+            assert.equal(err.message, 'boom!');
+            done();
+          });
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
**THIS IS A BREAKING CHANGE**. This patch prevents unhandled Promise rejections from crashing the process by allowing the caller to handle them instead.

To properly call `Builder#analyze()`, you must change your code from:

```js
builder.analyze(function(results) {
  // Do something with results
});
```

To:

```js
builder.analyze(function(err, results) {
  if (err) {
    // handle error
  }

  // Do something with results
});
```

Additionally, when using the Promise returned by `Builder#analyze()`, you must add a `.catch()` block to handle the possible rejection. For example:

```js
builder
  .analyze()
  .then(results => {
    // Do something with results
  })
  .catch(err => {
    // handle error
  });
```

NOTE: when using a Promise _and_ a callback, the Promise will never be rejected. The callback will be provided the error instead. This ensures we don't require users to handle the same error twice.

Fixes #56.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Follows the commit message policy, appropriate for next version
- [ ] Has documentation updated, a DU ticket, or requires no documentation change
- [ ] Includes new tests, or was unnecessary
- [ ] Code is reviewed for security by: << Name here >>
