### PR TITLE
ci: restore cache before publishing

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -35,6 +35,8 @@ jobs:
     <<: *defaults
     steps:
       - checkout
+      - restore_cache:
+          key: v2-npm-cache-{{ checksum "package.json" }}
       - run: npm config set "//registry.npmjs.org/:_authToken" $NPM_AUTH
       - run: npm publish
 


### PR DESCRIPTION
This patch fixes the auto-publishing by restoring cache before running `npm publish`.


## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @WilcoFiers 
