### PR TITLE
Fix: adapt analyze calls to new format

### DIFF
--- a/test/integration/doc-lang.js
+++ b/test/integration/doc-lang.js
@@ -43,7 +43,8 @@ describe('doc-lang.html', function() {
   it('should find violations', function(done) {
     AxeBuilder(driver)
       .withRules('html-has-lang')
-      .analyze(function(results) {
+      .analyze()
+      .then(function(results) {
         assert.lengthOf(results.violations, 1);
         assert.equal(results.violations[0].id, 'html-has-lang');
         assert.lengthOf(results.passes, 0);
@@ -55,7 +56,8 @@ describe('doc-lang.html', function() {
     AxeBuilder(driver)
       .include('body')
       .withRules('html-has-lang')
-      .analyze(function(results) {
+      .analyze()
+      .then(function(results) {
         assert.lengthOf(results.violations, 0);
         assert.lengthOf(results.passes, 0);
         done();

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -202,7 +202,8 @@ describe('Builder', function() {
         .include('.joe')
         .exclude('.fred')
         .exclude('.bob')
-        .analyze(function() {
+        .analyze()
+        .then(function() {
           assert.isTrue(normalized);
           done();
         });


### PR DESCRIPTION
Found a few scenarios where the method analyse doesn't match with the new spec.
I made the original comment here https://github.com/dequelabs/axe-webdriverjs/pull/83

PR Created following the recommendation of @stephenmathieson 


Closes issue:
https://github.com/dequelabs/axe-webdriverjs/issues/92 and complete https://github.com/dequelabs/axe-webdriverjs/pull/83

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Stephen