### PR TITLE
fix: Log "iframe warning" to stderr

### DIFF
--- a/lib/axe-injector.js
+++ b/lib/axe-injector.js
@@ -17,7 +17,7 @@ class AxeInjector {
 
     this.didLogError = true;
     // eslint-disable-next-line no-console
-    console.log('Failed to inject axe-core into one of the iframes!');
+    console.error('Failed to inject axe-core into one of the iframes!');
   }
 
   // Get axe-core source (and configuration)

--- a/test/unit/axe-injector.js
+++ b/test/unit/axe-injector.js
@@ -46,9 +46,24 @@ describe('AxeInjector', () => {
   });
 
   describe('errorHandler', () => {
+    // See https://github.com/dequelabs/axe-cli/issues/87.
+    it('writes to stderr (not stdout)', () => {
+      const injector = new AxeInjector({ driver: new MockWebDriver() });
+      const logSpy = sinon.spy(console, 'log');
+      const errorSpy = sinon.spy(console, 'error');
+
+      injector.errorHandler();
+
+      assert.equal(logSpy.callCount, 0);
+      logSpy.restore();
+
+      assert.equal(errorSpy.callCount, 1);
+      errorSpy.restore();
+    });
+
     it('only logs once', () => {
       const injector = new AxeInjector({ driver: new MockWebDriver() });
-      const spy = sinon.spy(console, 'log');
+      const spy = sinon.spy(console, 'error');
 
       injector.errorHandler();
       injector.errorHandler();


### PR DESCRIPTION
This patch moves the "iframe warning" log to stderr (from stdout).

Ref: https://github.com/dequelabs/axe-cli/issues/87



## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @WilcoFiers
