### PR TITLE
feat: Add `logIframeErrors` option to not print iframe error to console

### DIFF
--- a/lib/axe-injector.js
+++ b/lib/axe-injector.js
@@ -1,8 +1,13 @@
 class AxeInjector {
-  constructor({ driver, config, axeSource = null }) {
+  constructor({ driver, config, axeSource = null, options = {} }) {
     this.driver = driver;
     this.axeSource = axeSource || require('axe-core').source;
     this.config = config ? JSON.stringify(config) : '';
+    this.options = options;
+
+    // default stdout to true so it retains the original behavior
+    this.options.stdout =
+      typeof this.options.stdout !== 'undefined' ? this.options.stdout : true;
 
     this.didLogError = false;
     this.errorHandler = this.errorHandler.bind(this);
@@ -16,8 +21,15 @@ class AxeInjector {
     }
 
     this.didLogError = true;
-    // eslint-disable-next-line no-console
-    console.error('Failed to inject axe-core into one of the iframes!');
+    const msg = 'Failed to inject axe-core into one of the iframes!';
+
+    if (this.options.stdout) {
+      // eslint-disable-next-line no-console
+      console.error(msg);
+      return;
+    }
+
+    throw new Error(msg);
   }
 
   // Get axe-core source (and configuration)
@@ -73,9 +85,13 @@ class AxeInjector {
   inject(callback) {
     this.injectIntoAllFrames()
       .then(() => callback())
-      // For now, we intentionally ignore errors here, as
-      // allowing them to bubble up would be a breaking change.
-      .catch(() => callback());
+      .catch(e => {
+        if (this.options.stdout) {
+          return callback();
+        }
+
+        callback(e);
+      });
   }
 }
 

--- a/lib/axe-injector.js
+++ b/lib/axe-injector.js
@@ -5,9 +5,11 @@ class AxeInjector {
     this.config = config ? JSON.stringify(config) : '';
     this.options = options;
 
-    // default stdout to true so it retains the original behavior
-    this.options.stdout =
-      typeof this.options.stdout !== 'undefined' ? this.options.stdout : true;
+    // default logIframeErrors to true so it retains the original behavior
+    this.options.logIframeErrors =
+      typeof this.options.logIframeErrors !== 'undefined'
+        ? this.options.logIframeErrors
+        : true;
 
     this.didLogError = false;
     this.errorHandler = this.errorHandler.bind(this);
@@ -23,7 +25,7 @@ class AxeInjector {
     this.didLogError = true;
     const msg = 'Failed to inject axe-core into one of the iframes!';
 
-    if (this.options.stdout) {
+    if (this.options.logIframeErrors) {
       // eslint-disable-next-line no-console
       console.error(msg);
       return;
@@ -86,7 +88,7 @@ class AxeInjector {
     this.injectIntoAllFrames()
       .then(() => callback())
       .catch(e => {
-        if (this.options.stdout) {
+        if (this.options.logIframeErrors) {
           return callback();
         }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@ var normalizeContext = require('./normalize-context');
  * Constructor for chainable WebDriver API
  * @param {WebDriver} driver WebDriver instance to analyze
  */
-function AxeBuilder(driver, source) {
+function AxeBuilder(driver, source, builderOptions = {}) {
   if (!(this instanceof AxeBuilder)) {
     return new AxeBuilder(driver, source);
   }
@@ -17,6 +17,7 @@ function AxeBuilder(driver, source) {
   this._excludes = [];
   this._options = null;
   this._config = null;
+  this._builderOptions = builderOptions;
 }
 
 /**
@@ -141,7 +142,12 @@ AxeBuilder.prototype.analyze = function(callback) {
   }
 
   return new Promise((resolve, reject) => {
-    var injector = new AxeInjector({ driver, axeSource: source, config });
+    var injector = new AxeInjector({
+      driver,
+      axeSource: source,
+      config,
+      options: this._builderOptions
+    });
     injector.inject(() => {
       driver
         .executeAsyncScript(

--- a/package-lock.json
+++ b/package-lock.json
@@ -5832,7 +5832,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -5864,7 +5864,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {

--- a/test/unit/axe-injector.js
+++ b/test/unit/axe-injector.js
@@ -72,6 +72,15 @@ describe('AxeInjector', () => {
 
       spy.restore();
     });
+
+    it('throws the error if stdout is set to false', () => {
+      const injector = new AxeInjector({
+        driver: new MockWebDriver(),
+        options: { stdout: false }
+      });
+
+      assert.throws(injector.errorHandler);
+    });
   });
 
   describe('script', () => {
@@ -214,6 +223,24 @@ describe('AxeInjector', () => {
       stub.rejects(new Error('oh no!'));
 
       injector.inject(done);
+    });
+
+    it('passes the error if stdout is set to false', done => {
+      const injector = new AxeInjector({
+        driver: new MockWebDriver(),
+        options: { stdout: false }
+      });
+      const stub = sinon.stub(injector, 'injectIntoAllFrames');
+
+      stub.rejects(new Error('oh no!'));
+
+      injector.inject(err => {
+        if (err) {
+          return done();
+        }
+
+        done('injector did not pass error to callback');
+      });
     });
   });
 });

--- a/test/unit/axe-injector.js
+++ b/test/unit/axe-injector.js
@@ -239,7 +239,7 @@ describe('AxeInjector', () => {
           return done();
         }
 
-        done('injector did not pass error to callback');
+        done(new Error('injector did not pass error to callback'));
       });
     });
   });


### PR DESCRIPTION
This uses the same option name as `axe-cli` with the idea being that it can just pass the option directly into this. The default is true so behavior doesn't change from before, and only passing `stdout: false` will cause it to throw the error.

Closes: #41 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @WilcoFiers 
