### PR TITLE
fix: Improve error message when an iframe was removed

### DIFF
--- a/lib/axe-injector.js
+++ b/lib/axe-injector.js
@@ -1,3 +1,5 @@
+const { StaleElementReferenceError } = require('selenium-webdriver').error;
+
 class AxeInjector {
   constructor({ driver, config, axeSource = null }) {
     this.driver = driver;
@@ -9,15 +11,20 @@ class AxeInjector {
   }
 
   // Single-shot error handler. Ensures we don't log more than once.
-  errorHandler() {
+  errorHandler(err) {
     // We've already "warned" the user. No need to do it again (mostly for backwards compatiability)
     if (this.didLogError) {
       return;
     }
 
     this.didLogError = true;
-    // eslint-disable-next-line no-console
-    console.error('Failed to inject axe-core into one of the iframes!');
+    if (err instanceof StaleElementReferenceError) {
+      // eslint-disable-next-line no-console
+      console.log('Tried to inject into a removed iframe. Please ensure the page has settled.')
+    } else {
+      // eslint-disable-next-line no-console
+      console.log('Failed to inject axe-core into one of the iframes!');
+    }
   }
 
   // Get axe-core source (and configuration)

--- a/lib/axe-injector.js
+++ b/lib/axe-injector.js
@@ -20,10 +20,10 @@ class AxeInjector {
     this.didLogError = true;
     if (err instanceof StaleElementReferenceError) {
       // eslint-disable-next-line no-console
-      console.log('Tried to inject into a removed iframe. Please ensure the page has settled.')
+      console.error('Tried to inject into a removed iframe. Please ensure the page has settled.')
     } else {
       // eslint-disable-next-line no-console
-      console.log('Failed to inject axe-core into one of the iframes!');
+      console.error('Failed to inject axe-core into one of the iframes!');
     }
   }
 

--- a/lib/axe-injector.js
+++ b/lib/axe-injector.js
@@ -20,7 +20,7 @@ class AxeInjector {
     this.didLogError = true;
     if (err instanceof StaleElementReferenceError) {
       // eslint-disable-next-line no-console
-      console.error('Tried to inject into a removed iframe. Please ensure the page has settled.')
+      console.error('Tried to inject into a removed iframe. This will not affect the analysis of the rest of the page but you might want to ensure the page has finished updating before starting the analysis.')
     } else {
       // eslint-disable-next-line no-console
       console.error('Failed to inject axe-core into one of the iframes!');


### PR DESCRIPTION
After trying many things, this is the best we can do. When a [`StaleElementReferenceError`](https://www.seleniumhq.org/exceptions/stale_element_reference.jsp) we have a reference to an element that was either deleted or detached from the DOM. And we _shouldn't_ be doing anything that could cause either of those things to occur. If a user's page causes Selenium to throw a `StaleElementReferenceError` then we our Axe results probably won't be consistent anyways.

So, the best solution is to inform the user that it is their page that is acting up and that it is their responsibility to get the page in a stable state before running Axe on it.



Closes issue: https://github.com/dequelabs/attest-node-suite/issues/246

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Stephen