### PR TITLE
fix: failed to inject into iframe issue

### DIFF
--- a/lib/axe-injector.js
+++ b/lib/axe-injector.js
@@ -1,4 +1,5 @@
 const { StaleElementReferenceError } = require('selenium-webdriver').error;
+const { By } = require('selenium-webdriver');
 
 class AxeInjector {
   constructor({ driver, config, axeSource = null, options = {} }) {
@@ -58,7 +59,7 @@ class AxeInjector {
     await this.driver.executeScript(this.script);
 
     // Get all of <iframe>s at this level
-    const frames = await this.driver.findElements({ tagName: 'iframe' });
+    const frames = await this.driver.findElements(By.tagName('iframe'));
 
     // Inject into each frame. Handling errors to ensure an issue on a single frame won't stop the rest of the injections.
     return Promise.all(
@@ -78,7 +79,7 @@ class AxeInjector {
     await this.driver.executeScript(this.script);
 
     // Get all of <iframe>s at this level
-    const frames = await this.driver.findElements({ tagName: 'iframe' });
+    const frames = await this.driver.findElements(By.tagName('iframe'));
 
     // Inject the script into all child frames. Handle errors to ensure we don't stop execution if we fail to inject.
     await Promise.all(

--- a/test/unit/axe-injector.js
+++ b/test/unit/axe-injector.js
@@ -143,7 +143,7 @@ describe('AxeInjector', () => {
       let didReturnIframes = false;
       const driver = new MockWebDriver({
         findElements(selector) {
-          assert.equal(selector.tagName, 'iframe');
+          assert.equal(selector.value, 'iframe');
           if (didReturnIframes) {
             return;
           }
@@ -189,7 +189,7 @@ describe('AxeInjector', () => {
       let didReturnIframes = false;
       const driver = new MockWebDriver({
         findElements(selector) {
-          assert.equal(selector.tagName, 'iframe');
+          assert.equal(selector.value, 'iframe');
           if (didReturnIframes) {
             return;
           }


### PR DESCRIPTION
Used `By` keyword to access `tagName` to get iframe instead of passing `{tagName: 'iframe'}` to findelements 

Closes issue: 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Follows the commit message policy, appropriate for next version
- [ ] Has documentation updated, a DU ticket, or requires no documentation change
- [ ] Includes new tests, or was unnecessary
- [ ] Code is reviewed for security by: << Name here >>
