### PR TITLE
fix: overrides sandbox attr on iframes

### DIFF
--- a/lib/axe-injector.js
+++ b/lib/axe-injector.js
@@ -104,7 +104,7 @@ class AxeInjector {
         /* eslint-enable no-undef */
         // resolve the outer promise
         .then(resolve)
-        .catch(err => reject(err));
+        .catch(e => reject(e));
     });
   }
   // Inject into all frames.

--- a/lib/axe-injector.js
+++ b/lib/axe-injector.js
@@ -1,11 +1,14 @@
 const { StaleElementReferenceError } = require('selenium-webdriver').error;
 
 class AxeInjector {
-  constructor({ driver, config, axeSource = null, options = {} }) {
+  constructor({ driver, config, axeSource = null, options = {}, sandbox }) {
     this.driver = driver;
     this.axeSource = axeSource || require('axe-core').source;
     this.config = config ? JSON.stringify(config) : '';
     this.options = options;
+
+    // default is set to true so it does not rewrite iframes in the DOM
+    this.sandbox = sandbox;
 
     // default logIframeErrors to true so it retains the original behavior
     this.options.logIframeErrors =
@@ -96,7 +99,8 @@ class AxeInjector {
         })
         /* eslint-enable no-undef */
         // resolve the outer promise
-        .then(resolve);
+        .then(resolve)
+        .catch(e => console.error(e));
     });
   }
 
@@ -105,9 +109,11 @@ class AxeInjector {
     // Ensure we're "starting" our loop at the top-most frame
     await this.driver.switchTo().defaultContent();
 
-    // reinject any sandboxed iframes without the sandbox attribute so we can scan it
-    await this.sandboxBuster();
-
+    // By default we do not remove the sandbox attr from iFrame unless user specifies
+    if (!this.sandbox) {
+      // reinject any sandboxed iframes without the sandbox attribute so we can scan
+      await this.sandboxBuster();
+    }
     // Inject the script into the top-level
     // XXX: if this `executeScript` fails, we *want* to error, as we cannot run axe-core.
     await this.driver.executeScript(this.script);

--- a/lib/axe-injector.js
+++ b/lib/axe-injector.js
@@ -8,7 +8,8 @@ class AxeInjector {
     this.options = options;
 
     // default is set to true so it does not rewrite iframes in the DOM
-    this.sandbox = sandbox;
+    // validates the value being passed to sandbox as a boolean
+    this.sandbox = typeof sandbox === 'boolean' ? sandbox : true;
 
     // default logIframeErrors to true so it retains the original behavior
     this.options.logIframeErrors =

--- a/lib/axe-injector.js
+++ b/lib/axe-injector.js
@@ -76,7 +76,7 @@ class AxeInjector {
     // outer promise needed because `executeAsyncScript`
     // does not return a "real promise" (ManagedPromise)
     // and we want to await it.
-    return new Promise(resolve => {
+    return new Promise((resolve, reject) => {
       /* eslint-disable no-undef */
       this.driver
         .executeAsyncScript(function(callback) {
@@ -101,7 +101,7 @@ class AxeInjector {
         /* eslint-enable no-undef */
         // resolve the outer promise
         .then(resolve)
-        .catch(e => console.error(e));
+        .catch(e => reject(e));
     });
   }
 

--- a/lib/axe-injector.js
+++ b/lib/axe-injector.js
@@ -1,7 +1,7 @@
 const { StaleElementReferenceError } = require('selenium-webdriver').error;
 
 class AxeInjector {
-  constructor({ driver, config, axeSource = null, options = {}, sandbox }) {
+  constructor({ driver, config, axeSource = null, options = {} }) {
     this.driver = driver;
     this.axeSource = axeSource || require('axe-core').source;
     this.config = config ? JSON.stringify(config) : '';
@@ -9,7 +9,10 @@ class AxeInjector {
 
     // default is set to true so it does not rewrite iframes in the DOM
     // validates the value being passed to sandbox as a boolean
-    this.sandbox = typeof sandbox === 'boolean' ? sandbox : true;
+    this.options.noSandbox =
+      typeof this.options.noSandbox === 'boolean'
+        ? this.options.noSandbox
+        : false;
 
     // default logIframeErrors to true so it retains the original behavior
     this.options.logIframeErrors =
@@ -76,7 +79,7 @@ class AxeInjector {
     // outer promise needed because `executeAsyncScript`
     // does not return a "real promise" (ManagedPromise)
     // and we want to await it.
-    return new Promise(resolve => {
+    return new Promise((resolve, reject) => {
       /* eslint-disable no-undef */
       this.driver
         .executeAsyncScript(function(callback) {
@@ -101,17 +104,16 @@ class AxeInjector {
         /* eslint-enable no-undef */
         // resolve the outer promise
         .then(resolve)
-        .catch(e => console.error(e));
+        .catch(err => reject(err));
     });
   }
-
   // Inject into all frames.
   async injectIntoAllFrames() {
     // Ensure we're "starting" our loop at the top-most frame
     await this.driver.switchTo().defaultContent();
 
-    // By default we do not remove the sandbox attr from iFrame unless user specifies
-    if (!this.sandbox) {
+    // By default we do not remove the sandbox attr from iframe unless user specifies
+    if (this.options.noSandbox) {
       // reinject any sandboxed iframes without the sandbox attribute so we can scan
       await this.sandboxBuster();
     }

--- a/lib/axe-injector.js
+++ b/lib/axe-injector.js
@@ -68,10 +68,45 @@ class AxeInjector {
     );
   }
 
+  async sandboxBuster() {
+    // outer promise needed because `executeAsyncScript`
+    // does not return a "real promise" (ManagedPromise)
+    // and we want to await it.
+    return new Promise(resolve => {
+      /* eslint-disable no-undef */
+      this.driver
+        .executeAsyncScript(function(callback) {
+          const iframes = Array.from(
+            document.querySelectorAll('iframe[sandbox]')
+          );
+          const removeSandboxAttr = clone => attr => {
+            if (attr.name === 'sandbox') return;
+            clone.setAttribute(attr.name, attr.value);
+          };
+          const replaceSandboxedIframe = iframe => {
+            const clone = document.createElement('iframe');
+            const promise = new Promise(
+              iframeLoaded => (clone.onload = iframeLoaded)
+            );
+            Array.from(iframe.attributes).forEach(removeSandboxAttr(clone));
+            iframe.parentElement.replaceChild(clone, iframe);
+            return promise;
+          };
+          Promise.all(iframes.map(replaceSandboxedIframe)).then(callback);
+        })
+        /* eslint-enable no-undef */
+        // resolve the outer promise
+        .then(resolve);
+    });
+  }
+
   // Inject into all frames.
   async injectIntoAllFrames() {
     // Ensure we're "starting" our loop at the top-most frame
     await this.driver.switchTo().defaultContent();
+
+    // reinject any sandboxed iframes without the sandbox attribute so we can scan it
+    await this.sandboxBuster();
 
     // Inject the script into the top-level
     // XXX: if this `executeScript` fails, we *want* to error, as we cannot run axe-core.

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,6 +18,7 @@ function AxeBuilder(driver, source, builderOptions = {}) {
   this._options = null;
   this._config = null;
   this._builderOptions = builderOptions;
+  this._sandbox = true;
 }
 
 /**
@@ -104,6 +105,18 @@ AxeBuilder.prototype.disableRules = function(rules) {
 };
 
 /**
+ * Rule to allow to replace sandboxed iFrames with a clone iFrame without the sandbox attribute
+ * @param {Boolean} sandbox
+ * @return {AxeBuilder}
+ */
+AxeBuilder.prototype.sandbox = function(sandbox) {
+  this._sandbox = sandbox;
+  console.log(sandbox);
+
+  return this;
+};
+
+/**
  * Configure aXe before running analyze. *Does not chain.*
  * @param  {Object} config Configuration object to use in analysis
  */
@@ -146,7 +159,8 @@ AxeBuilder.prototype.analyze = function(callback) {
       driver,
       axeSource: source,
       config,
-      options: this._builderOptions
+      options: this._builderOptions,
+      sandbox: this._sandbox
     });
     injector.inject(() => {
       driver

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,6 @@ function AxeBuilder(driver, source, builderOptions = {}) {
   this._options = null;
   this._config = null;
   this._builderOptions = builderOptions;
-  this._sandbox = true;
 }
 
 /**
@@ -100,18 +99,6 @@ AxeBuilder.prototype.disableRules = function(rules) {
       };
     }.bind(null, this._options.rules)
   );
-
-  return this;
-};
-
-/**
- * Rule to allow to replace sandboxed iFrames with a clone iFrame without the sandbox attribute
- * @param {Boolean} sandbox
- * @return {AxeBuilder}
- */
-AxeBuilder.prototype.sandbox = function(sandbox) {
-  this._sandbox = sandbox;
-  console.log(sandbox);
 
   return this;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -146,9 +146,8 @@ AxeBuilder.prototype.analyze = function(callback) {
       driver,
       axeSource: source,
       config,
-      options: this._builderOptions,
-      sandbox: this._sandbox
-    });
+      options: this._builderOptions
+		});
     injector.inject(() => {
       driver
         .executeAsyncScript(

--- a/lib/index.js
+++ b/lib/index.js
@@ -147,7 +147,7 @@ AxeBuilder.prototype.analyze = function(callback) {
       axeSource: source,
       config,
       options: this._builderOptions
-		});
+    });
     injector.inject(() => {
       driver
         .executeAsyncScript(

--- a/test/fixtures/sandbox-outer-configure-frame.html
+++ b/test/fixtures/sandbox-outer-configure-frame.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html lang="FFFF">
+<head>
+	<title>Configure Frame Test</title>
+</head>
+<body>
+	<iframe sandbox src="inner-configure-frame.html" title="Test inner frame"></iframe>
+</body>
+</html>

--- a/test/integration/configure-frames.js
+++ b/test/integration/configure-frames.js
@@ -66,3 +66,62 @@ describe('outer-configure-frame.html', function() {
       });
   });
 });
+
+describe('sandbox-outer-configure-frame.html', function() {
+  this.timeout(10000);
+
+  var server;
+  var driver;
+  before(function(done) {
+    driver = runWebdriver();
+    driver
+      .manage()
+      .timeouts()
+      .setScriptTimeout(10000);
+
+    server = createServer({
+      root: path.resolve(__dirname, '../..'),
+      cache: -1
+    });
+    server.listen(9876, err => {
+      if (err) {
+        return done(err);
+      }
+      driver
+        .get(
+          'http://' +
+            host +
+            ':9876/test/fixtures/sandbox-outer-configure-frame.html'
+        )
+        .then(function() {
+          done();
+        });
+    });
+  });
+
+  after(function() {
+    server.close();
+    driver.quit();
+  });
+
+  it('should find configured violations in all frames', function(done) {
+    AxeBuilder(driver)
+      .options({
+        rules: {
+          'landmark-one-main': { enabled: false },
+          'page-has-heading-one': { enabled: false },
+          region: { enabled: false },
+          'html-lang-valid': { enabled: false }
+        }
+      })
+      .configure(json)
+      .analyze()
+      .then(function(results) {
+        assert.equal(results.violations[0].id, 'dylang');
+        // the second violation is in a frame
+        assert.equal(results.violations[0].nodes.length, 2);
+
+        done();
+      });
+  });
+});

--- a/test/integration/configure-frames.js
+++ b/test/integration/configure-frames.js
@@ -106,6 +106,7 @@ describe('sandbox-outer-configure-frame.html', function() {
 
   it('should find configured violations in all frames', function(done) {
     AxeBuilder(driver)
+      .sandbox(false)
       .options({
         rules: {
           'landmark-one-main': { enabled: false },

--- a/test/integration/configure-frames.js
+++ b/test/integration/configure-frames.js
@@ -105,8 +105,8 @@ describe('sandbox-outer-configure-frame.html', function() {
   });
 
   it('should find configured violations in all frames', function(done) {
-    AxeBuilder(driver)
-      .sandbox(false)
+    var axeBuilder = new AxeBuilder(driver, null, { noSandbox: true });
+    axeBuilder
       .options({
         rules: {
           'landmark-one-main': { enabled: false },

--- a/test/unit/axe-injector.js
+++ b/test/unit/axe-injector.js
@@ -22,6 +22,10 @@ class MockWebDriver {
     return Promise.resolve();
   }
 
+  executeAsyncScript() {
+    return Promise.resolve();
+  }
+
   findElements() {
     return Promise.resolve([]);
   }


### PR DESCRIPTION
Removes and re-injects sandboxed iframes without the sandbox attribute prior to injecting axe.

Paired with: @michael-siek 

Closes issue: dequelabs/attest-node-suite#246 dequelabs/attest-node-suite#332

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @AutoSponge 
