### PR TITLE
fix: properly switch to sibling frames

### DIFF
--- a/lib/axe-injector.js
+++ b/lib/axe-injector.js
@@ -59,20 +59,34 @@ class AxeInjector {
   }
 
   // Inject into the provided `frame` and its child `frames`
-  async handleFrame(frame) {
+  async handleFrame(framePath) {
+    // Move back to the top-most frame
+    await this.driver.switchTo().defaultContent();
     // Switch context to the frame and inject our `script` into it
-    await this.driver.switchTo().frame(frame);
+    for (const frame of framePath) {
+      await this.driver.switchTo().frame(frame);
+    }
     await this.driver.executeScript(this.script);
 
     // Get all of <iframe>s at this level
     const frames = await this.driver.findElements({ tagName: 'iframe' });
 
     // Inject into each frame. Handling errors to ensure an issue on a single frame won't stop the rest of the injections.
-    return Promise.all(
-      frames.map(childFrame =>
-        this.handleFrame(childFrame).catch(this.errorHandler)
-      )
-    );
+    for (const childFrame of frames) {
+      framePath.push(childFrame);
+      try {
+        await this.handleFrame(framePath);
+      } catch (err) {
+        this.errorHandler(err);
+      } finally {
+        framePath.pop();
+      }
+    }
+    // Move back to the parent frame
+    const targetLocator = this.driver.switchTo();
+    if ('parentFrame' in targetLocator) {
+      await targetLocator.parentFrame();
+    }
   }
 
   async sandboxBuster() {
@@ -125,11 +139,13 @@ class AxeInjector {
     const frames = await this.driver.findElements({ tagName: 'iframe' });
 
     // Inject the script into all child frames. Handle errors to ensure we don't stop execution if we fail to inject.
-    await Promise.all(
-      frames.map(childFrame =>
-        this.handleFrame(childFrame).catch(this.errorHandler)
-      )
-    );
+    for (const childFrame of frames) {
+      try {
+        await this.handleFrame([childFrame]);
+      } catch (err) {
+        this.errorHandler(err);
+      }
+    }
 
     // Move back to the top-most frame
     return this.driver.switchTo().defaultContent();

--- a/lib/axe-injector.js
+++ b/lib/axe-injector.js
@@ -82,11 +82,6 @@ class AxeInjector {
         framePath.pop();
       }
     }
-    // Move back to the parent frame
-    const targetLocator = this.driver.switchTo();
-    if ('parentFrame' in targetLocator) {
-      await targetLocator.parentFrame();
-    }
   }
 
   async sandboxBuster() {

--- a/test/unit/axe-injector.js
+++ b/test/unit/axe-injector.js
@@ -123,15 +123,15 @@ describe('AxeInjector', () => {
         driver: new MockWebDriver({
           switchTo() {
             return {
+              defaultContent() {},
               frame(frame) {
-                assert.equal(frame, 1);
-                switched = true;
+                switched |= frame == 1;
               }
             };
           }
         })
       });
-      await injector.handleFrame(1);
+      await injector.handleFrame([1]);
       assert(switched);
     });
 
@@ -139,7 +139,7 @@ describe('AxeInjector', () => {
       const driver = new MockWebDriver();
       const executeScript = sinon.spy(driver, 'executeScript');
       const injector = new AxeInjector({ driver });
-      await injector.handleFrame(1);
+      await injector.handleFrame([1]);
       assert(executeScript.calledOnce);
     });
 
@@ -158,7 +158,7 @@ describe('AxeInjector', () => {
 
       const injector = new AxeInjector({ driver });
       const executeScript = sinon.spy(driver, 'executeScript');
-      await injector.handleFrame(1);
+      await injector.handleFrame([1]);
       // once for the top-frame and 4 more for the other frames
       assert.equal(executeScript.callCount, 5);
     });


### PR DESCRIPTION
Frame context code was not properly switching frames due to context
being switched. You have to go back to the parent frame.

If we only needed to support selenium-webdriver@4.0.0 this would be a 1
line change adding a call to `driver.switchTo().parentFrame()`.

Closes issue: https://github.com/dequelabs/attest-node-suite/issues/246

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
