### PR TITLE
ci: fix issue with failing test in CI

### DIFF
--- a/test/run-webdriver.js
+++ b/test/run-webdriver.js
@@ -6,7 +6,7 @@ function runWebdriver() {
   // Adding this should fix the weird CI failing issue
   // https://github.com/SeleniumHQ/selenium/issues/4961
   var chromeOptions = {
-    args: ['--no-sandbox']
+    args: ['--no-sandbox', '--headless', '--disable-gpu']
   };
   chromeCapabilities.set('chromeOptions', chromeOptions);
   if (process.env.REMOTE_SELENIUM_URL) {

--- a/test/run-webdriver.js
+++ b/test/run-webdriver.js
@@ -1,14 +1,24 @@
 var WebDriver = require('selenium-webdriver');
+var chromeCapabilities = WebDriver.Capabilities.chrome();
 
 function runWebdriver() {
   var webdriver;
+  // Adding this should fix the weird CI failing issue
+  // https://github.com/SeleniumHQ/selenium/issues/4961
+  var chromeOptions = {
+    args: ['--no-sandbox']
+  };
+  chromeCapabilities.set('chromeOptions', chromeOptions);
   if (process.env.REMOTE_SELENIUM_URL) {
     webdriver = new WebDriver.Builder()
       .forBrowser('chrome')
       .usingServer(process.env.REMOTE_SELENIUM_URL)
       .build();
   } else {
-    webdriver = new WebDriver.Builder().forBrowser('chrome').build();
+    webdriver = new WebDriver.Builder()
+      .withCapabilities(chromeCapabilities)
+      .forBrowser('chrome')
+      .build();
   }
 
   return webdriver;


### PR DESCRIPTION
Add chromeOptions to allow test to run headless in CI which should stop failing test.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
