### PR TITLE
docs: replace dead link to selenium webdriver

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Provides a chainable axe API for Selenium's WebDriverJS and automatically inject
 
 Install [Node.js](https://docs.npmjs.com/getting-started/installing-node) if you haven't already. For running axe-webdriverjs tests read more about [setting up your environment](CONTRIBUTING.md).
 
-> Download and install any necessary browser drivers on your machine's PATH. [More on Webdriver setup](https://seleniumhq.github.io/docs/wd.html).
+> Download and install any necessary browser drivers on your machine's PATH. [More on Webdriver setup](https://www.selenium.dev/documentation/en/webdriver/).
 
 Install Selenium Webdriver: `npm install selenium-webdriver --no-save`
 


### PR DESCRIPTION
docs have moved to https://www.selenium.dev/documentation/en/
