### PR TITLE
feature(package): uplift axe-core dependency to 4.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -588,9 +588,9 @@
       "optional": true
     },
     "axe-core": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.4.1.tgz",
-      "integrity": "sha512-+EhIdwR0hF6aeMx46gFDUy6qyCfsL0DmBrV3Z+LxYbsOd8e1zBaPHa3f9Rbjsz2dEwSBkLw6TwML/CAIIAqRpw=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.0.1.tgz",
+      "integrity": "sha512-OSCABHvSNDleKqJP7DUwEBvMVbr/gtOj2vCDoKKz967fxe9WqtCZLo3IRNOO2fJcu+eSFsu8aAToHfIY7sPLaw=="
     },
     "axios": {
       "version": "0.19.2",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "standard-version": "^8.0.1"
   },
   "dependencies": {
-    "axe-core": "^3.4.1",
+    "axe-core": "^4.0.1",
     "babel-runtime": "^6.26.0",
     "depd": "^2.0.0"
   },

--- a/test/integration/configure-frames.js
+++ b/test/integration/configure-frames.js
@@ -51,6 +51,7 @@ describe('outer-configure-frame.html', function() {
         rules: {
           'landmark-one-main': { enabled: false },
           'page-has-heading-one': { enabled: false },
+          bypass: { enabled: false },
           region: { enabled: false },
           'html-lang-valid': { enabled: false }
         }
@@ -111,6 +112,7 @@ describe('sandbox-outer-configure-frame.html', function() {
         rules: {
           'landmark-one-main': { enabled: false },
           'page-has-heading-one': { enabled: false },
+          bypass: { enabled: false },
           region: { enabled: false },
           'html-lang-valid': { enabled: false }
         }
@@ -171,6 +173,7 @@ describe('sandbox-nested-configure-frame.html', function() {
         rules: {
           'landmark-one-main': { enabled: false },
           'page-has-heading-one': { enabled: false },
+          bypass: { enabled: false },
           region: { enabled: false },
           'html-lang-valid': { enabled: false }
         }

--- a/test/integration/shadow-dom.js
+++ b/test/integration/shadow-dom.js
@@ -69,6 +69,7 @@ describe('shadow-dom.html', function() {
           rules: {
             'landmark-one-main': { enabled: false },
             'page-has-heading-one': { enabled: false },
+            bypass: { enabled: false },
             region: { enabled: false }
           }
         })


### PR DESCRIPTION
Uplift of axe-core from v3.4.1 to v4.0.1 to take advantage of bug fixes and new checks. Update the tests to account for the addition of the `bypass` rule.

Closes issue:

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Follows the commit message policy, appropriate for next version
- [ ] Code is reviewed for security
